### PR TITLE
Changed Name in package.json to reflect Project Name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "roon-mqtt-extension",
+    "name": "roon-extension-mqtt",
     "version": "0.0.1",
     "description": "Roon Extension to provde status to MQTT Broker",
     "main": "roon-mqtt.js",


### PR DESCRIPTION
The Naming mismatch was preventing the MQQT extension from loading within the Extension manager.   If accepted, ext step would be to add the MQTT extension to the Extension manager repository, i have added to my local repo and installed via Extension-Manager. 