### PR TITLE
Retain for roon/online and last will

### DIFF
--- a/roon-mqtt.js
+++ b/roon-mqtt.js
@@ -41,7 +41,7 @@ function mqtt_get_client() {
 		options.clean = true;
 		options.clientId = "roon-extension-mqtt-" + (Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5)); //+= "." + hostname;
 		options.servername = mysettings.mqttbroker;
-		options.will = { topic: 'roon/online', payload: 'false', retain: 'true' };
+		options.will = { topic: 'roon/online', payload: 'false', retain: true };
 		if ( mysettings.mqttusername && mysettings.mqttpassword ) {
 			options.username = mysettings.mqttusername;
 			options.password = mysettings.mqttpassword;

--- a/roon-mqtt.js
+++ b/roon-mqtt.js
@@ -14,7 +14,7 @@ var RoonApi 			= require("node-roon-api"),
 
 function mqtt_publish_JSON( mqttbase, mqtt_client, jsondata ) {
 	if ( mqtt_client && mqtt_client.connected ) {
-		mqtt_client.publish('roon/online','true');
+//		mqtt_client.publish('roon/online','true');
 		for ( var attribute in jsondata ) {
 			if ( typeof jsondata[attribute] === 'object' ) {
 				mqtt_publish_JSON( mqttbase+'/'+attribute, mqtt_client, jsondata[attribute] );
@@ -41,6 +41,7 @@ function mqtt_get_client() {
 		options.clean = true;
 		options.clientId = "roon-extension-mqtt-" + (Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5)); //+= "." + hostname;
 		options.servername = mysettings.mqttbroker;
+		options.will = { topic: 'roon/online', payload: 'false', retain: 'true' };
 		if ( mysettings.mqttusername && mysettings.mqttpassword ) {
 			options.username = mysettings.mqttusername;
 			options.password = mysettings.mqttpassword;
@@ -65,7 +66,7 @@ function mqtt_get_client() {
 		});
 		
 		mqtt_client.on('connect', () => {
-			mqtt_client.publish('roon/online','true');
+			mqtt_client.publish('roon/online','true', 'retain: true');
 			mqtt_client.subscribe('roon/+/command');
 			mqtt_client.subscribe('roon/+/outputs/+/volume/set');
 			roon_svc_status.set_status("MQTT Broker Connected", false);

--- a/roon-mqtt.js
+++ b/roon-mqtt.js
@@ -66,7 +66,7 @@ function mqtt_get_client() {
 		});
 		
 		mqtt_client.on('connect', () => {
-			mqtt_client.publish('roon/online','true', 'retain: true');
+			mqtt_client.publish('roon/online','true',{retain: true});
 			mqtt_client.subscribe('roon/+/command');
 			mqtt_client.subscribe('roon/+/outputs/+/volume/set');
 			roon_svc_status.set_status("MQTT Broker Connected", false);


### PR DESCRIPTION
To reduce traffic and have a trustful "false" for online status I have implemented a last will with cration of the connection and also set a retain for those both messages. So a client newly connecting and subscribing to roon/online with always get the right status immediately.

IMO the frequent publishing in line 17 is not needed anymore.