### PR TITLE
Slimmer base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM node:latest
+FROM node:lts-buster-slim
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+  && apt-get -y upgrade \
+  && apt-get install -qqy --no-install-recommends bash curl bzip2 git \
+  && apt-get autoremove -y && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Create app directory
 RUN mkdir -p /usr/src/app/config


### PR DESCRIPTION
I have choosen a slimmer base image, the newer debian buster slim instead of full debian stretch. 
It is also from the more stable long term service release (12.x at the moment).

I have also tested the alpine base, but this does not work out of the box and would need some further investigation.